### PR TITLE
Force Compile with Python 2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,3 +1,5 @@
+#!python2
+# Force Python to compile with 2.x when 3.x is also present on dev system.
 #
 # setup.py
 #


### PR DESCRIPTION
Added a directive to force the `.egg` to be generated with Python 2 on systems with Python 3 also installed. Should not affect end user once `.egg` is compiled.