### PR TITLE
fix errors from deluged logs

### DIFF
--- a/defaulttrackers/core.py
+++ b/defaulttrackers/core.py
@@ -67,7 +67,7 @@ class Core(CorePluginBase):
     def update(self):
         pass
 
-    def on_torrent_added(self, torrent_id):
+    def on_torrent_added(self, torrent_id, from_state=False):
         torrent = component.get("TorrentManager")[torrent_id]
         if (torrent.torrent_info and torrent.torrent_info.priv()) or torrent.get_status(["private"])["private"]:
             return
@@ -96,4 +96,3 @@ class Core(CorePluginBase):
     def get_config(self):
         """Returns the config dictionary"""
         return self.config.config
-


### PR DESCRIPTION
running against the latest develop branch trows a bunch of errors

```
03:24:54.264 [ERROR   ][deluge.core.eventmanager         :37  ] Event handler TorrentAddedEvent failed in <bound method Core.on_torrent_added of <defaulttrackers.core.Core object at 0x68190ce29410>> with exception on_t
orrent_added() takes exactly 2 arguments (3 given)
03:24:54.264 [INFO    ][deluge.core.torrentmanager       :452 ] Torrent Family.Guy.S15E01.The.Boys.in.the.Band.1080p.WEB-DL.DD5.1.H264-CtrlHD[rarbg] from user "localclient" loaded
03:24:54.265 [ERROR   ][deluge.core.eventmanager         :37  ] Event handler TorrentAddedEvent failed in <bound method Core.on_torrent_added of <defaulttrackers.core.Core object at 0x68190ce29410>> with exception on_t
orrent_added() takes exactly 2 arguments (3 given)
03:24:54.266 [INFO    ][deluge.core.torrentmanager       :452 ] Torrent Mind.In.A.Box[FLAC-LOSSLESS] from user "localclient" loaded
03:24:54.266 [ERROR   ][deluge.core.eventmanager         :37  ] Event handler TorrentAddedEvent failed in <bound method Core.on_torrent_added of <defaulttrackers.core.Core object at 0x68190ce29410>> with exception on_t
orrent_added() takes exactly 2 arguments (3 given)
03:24:54.267 [INFO    ][deluge.core.torrentmanager       :452 ] Torrent Crazy People 1990 DvDrip[Eng]-greenbud1969 from user "localclient" loaded
03:24:54.267 [ERROR   ][deluge.core.eventmanager         :37  ] Event handler TorrentAddedEvent failed in <bound method Core.on_torrent_added of <defaulttrackers.core.Core object at 0x68190ce29410>> with exception on_t
orrent_added() takes exactly 2 arguments (3 given)
03:24:54.268 [INFO    ][deluge.core.torrentmanager       :452 ] Torrent Kumonosu-jo from user "localclient" loaded
03:24:54.269 [ERROR   ][deluge.core.eventmanager         :37  ] Event handler TorrentAddedEvent failed in <bound method Core.on_torrent_added of <defaulttrackers.core.Core object at 0x68190ce29410>> with exception on_t
orrent_added() takes exactly 2 arguments (3 given)
```