### PR TITLE
Add dynamic Trackerlist Support

### DIFF
--- a/defaulttrackers/core.py
+++ b/defaulttrackers/core.py
@@ -45,10 +45,19 @@ import deluge.configmanager
 from deluge.core.rpcserver import export
 
 DEFAULT_PREFS = {
+    "dynamic_trackerlist":"https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_all.txt",
     "trackers": [
         #{"url": "test"},
     ],
 }
+
+if DEFAULT_PREFS["dynamic_trackerlist"]:
+    import urllib2 as u2
+    trackers = u2.urlopen(DEFAULT_PREFS["dynamic_trackerlist"]).read()
+    trackers = [ {"url":n} for n in trackers.split("\n\n") if n ]
+    del u2
+    DEFAULT_PREFS["trackers"]+=trackers
+    del trackers
 
 log = logging.getLogger(__name__)
 

--- a/defaulttrackers/core.py
+++ b/defaulttrackers/core.py
@@ -45,19 +45,10 @@ import deluge.configmanager
 from deluge.core.rpcserver import export
 
 DEFAULT_PREFS = {
-    "dynamic_trackerlist":"https://raw.githubusercontent.com/ngosang/trackerslist/master/trackers_all.txt",
     "trackers": [
         #{"url": "test"},
     ],
 }
-
-if DEFAULT_PREFS["dynamic_trackerlist"]:
-    import urllib2 as u2
-    trackers = u2.urlopen(DEFAULT_PREFS["dynamic_trackerlist"]).read()
-    trackers = [ {"url":n} for n in trackers.split("\n\n") if n ]
-    del u2
-    DEFAULT_PREFS["trackers"]+=trackers
-    del trackers
 
 log = logging.getLogger(__name__)
 


### PR DESCRIPTION
I probably did this in a very horrible way, but it works for me ;-)

Added a Way to fetch a text based Trackerlist via http and add it to new torrents. 
I stored the URL to the list in "dynamic_trackerlist", the fetched trackers in "dynamic_trackers".
I update and join it to "trackers" every time a new torrent is added.

Probably it would be better to check the age of the fetched trackerlist so it is not downloaded for every torrent upon restart.