### PR TITLE
Enforcing six version on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -73,7 +73,7 @@ setup(
     packages=[__plugin_name__.lower()],
     package_data = __pkg_data__,
     install_requires=[
-        'six',
+        'six>=1.12',
     ],
 
     entry_points="""


### PR DESCRIPTION
This plugin uses a [function from six that was introduced on version 1.12](https://github.com/benjaminp/six/blob/d927b9e27617abca8dbf4d66cc9265ebbde261d6/CHANGES#L6), so now we will install the right six version.

