### PR TITLE
Drop support for Python 2 (remove six dependency)

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ supposed to reach public trackers.
 
 Besides manually creating the default tracker list, you can also load it (periodically) from a URL.
 
-This plugin is compatible with Deluge 1.3 and 2.0, Python2 2.7 and Python3 3.5+.
+This plugin is compatible with Deluge 2.0 and Python 3.6+.
 
 ## Installation
 
@@ -21,8 +21,6 @@ This plugin is compatible with Deluge 1.3 and 2.0, Python2 2.7 and Python3 3.5+.
 (or try to use [the one from the "egg" directory][2] - be careful to install the py2.7 version of Deluge, if you're using Windows)
 
 * you need to use the same version of Python as the one that Deluge is running under.
-
-* if you're using it with Deluge-1.3, you might not have [six](https://pypi.org/project/six/) installed. Install it.
 
 * add it to Deluge from Preferences -> Plugins -> Install Plugin
 

--- a/defaulttrackers/core.py
+++ b/defaulttrackers/core.py
@@ -45,7 +45,7 @@ import re
 import ssl
 import time
 import traceback
-import six
+import urllib
 
 from deluge.common import is_url
 from deluge.core.rpcserver import export
@@ -95,13 +95,13 @@ class Core(CorePluginBase):
                             'Accept-Language': 'en-US,en;q=0.8',
                             }
 
-                    req = six.moves.urllib.request.Request(self.config["dynamic_trackerlist_url"], headers=headers)
+                    req = urllib.request.Request(self.config["dynamic_trackerlist_url"], headers=headers)
                     try:
-                        page = six.moves.urllib.request.urlopen(req, context=ssl._create_unverified_context()).read()
+                        page = urllib.request.urlopen(req, context=ssl._create_unverified_context()).read()
                     except:
                         # maybe an older Python version without a "context" argument
-                        page = six.moves.urllib.request.urlopen(req).read()
-                    new_trackers = [six.ensure_str(url) for url in re.findall(b'\w+://[\w\-.:/]+', page) if is_url(six.ensure_text(url))]
+                        page = urllib.request.urlopen(req).read()
+                    new_trackers = [url for url in re.findall(b'\w+://[\w\-.:/]+', page) if is_url(url)]
                     if new_trackers:
                         # replace all existing trackers
                         self.config["trackers"] = []

--- a/setup.py
+++ b/setup.py
@@ -45,7 +45,7 @@ from setuptools import setup
 __plugin_name__ = "DefaultTrackers"
 __author__ = u"Ștefan Talpalaru"
 __author_email__ = "stefantalpalaru@yahoo.com"
-__version__ = "0.2"
+__version__ = "0.3"
 __url__ = "https://github.com/stefantalpalaru/deluge-default-trackers"
 __license__ = "GPLv3"
 __description__ = "Add a list of default trackers to all the public torrents"
@@ -71,10 +71,8 @@ setup(
     long_description=__long_description__ if __long_description__ else __description__,
 
     packages=[__plugin_name__.lower()],
-    package_data = __pkg_data__,
-    install_requires=[
-        'six>=1.12',
-    ],
+    package_data=__pkg_data__,
+    install_requires=[],
 
     entry_points="""
     [deluge.plugin.core]


### PR DESCRIPTION
Six dependency is not installed in LinuxServer Deluge Docker image. https://hub.docker.com/r/linuxserver/deluge
In this PR I removed the six dependency, and therefore, Python2 support. Tested with Deluge 2.0.3  + Python 3.6

Compiled egg (rename .zip extension to .egg):
[DefaultTrackers-0.3-py3.6.zip](https://github.com/stefantalpalaru/deluge-default-trackers/files/5824741/DefaultTrackers-0.3-py3.6.zip)
